### PR TITLE
Always override the dependencies version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -501,9 +501,6 @@ EngineTools.prototype.installModule = function (project, module, callback) {
 
 
             function add(clb) {
-                if (pack.dependencies[modInfo.name]) {
-                    return clb();
-                }
                 pack.dependencies[modInfo.name] = modInfo.fromNpm ? modInfo.version : modInfo.git_url;
                 FsPlus.writeJSON(self.projectPackPath(project), pack, clb);
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engine-tools",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Engine Tools library and CLI app.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
This is a minor improvement to the `installModule` function: always override the dependencies with the latest type of input.
