### PR TITLE
Set the correct module instance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -538,9 +538,10 @@ EngineTools.prototype.installModule = function (project, module, callback) {
  */
 EngineTools.prototype.linkData = function (callback) {
     return function (link) {
+        var inst = this;
         link.data(function (err, data) {
             if (err) { return link.end(err); }
-            callback.call(link, data, link);
+            callback.call(inst, data, link);
         });
     };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engine-tools",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Engine Tools library and CLI app.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
This fixes the following problem:

``` js
exports.foo = EngineTools.linkData(function (data, link) {
   var self = this; // before this fix, `this` was the link object
});
```
