### PR TITLE
Added the iName option for getComposition.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -190,10 +190,15 @@ EngineTools.prototype.getInstances = function (project, callback) {
  * @param {String} project The project name.
  * @param {Function} callback The callback function.
  */
-EngineTools.prototype.getComposition = function (project, callback) {
+EngineTools.prototype.getComposition = function (project, options, callback) {
     var self = this
       , result = {}
       ;
+
+    if (typeof options === "function") {
+        callback = options;
+        options = {};
+    }
 
     OneByOne([
         self.getInstances.bind(self, project)
@@ -201,6 +206,9 @@ EngineTools.prototype.getComposition = function (project, callback) {
             SameTime(instances.map(function (c) {
                 return function (cb) {
                     ReadJson(c, function (err, comp) {
+                        if (options.iName) {
+                            c = self.nameFromInstancePath(c);
+                        }
                         result[c] = comp;
                         cb(err, comp);
                     });
@@ -633,21 +641,32 @@ EngineTools.prototype.linkData = function (callback) {
  */
 EngineTools.prototype.checkNames = function (project, callback) {
     var self = this;
-    self.getComposition(project, function (err, composition) {
+    self.getComposition(project, { iName: true }, function (err, composition) {
         if (err) { return callback(err); }
-        Object.keys(composition).forEach(function (cPath) {
-            var cBasename = Path.basename(cPath).replace(/\.json$/, "")
-              , cInstance = composition[cPath]
-              ;
+        Object.keys(composition).forEach(function (cName) {
+            var cInstance = composition[cPath];
 
             if (typeof cInstance.name !== "string") {
-                return callback(new Error("Missing or invalid `name` field in composition file: " + cPath));
+                return callback(new Error("Missing or invalid `name` field in composition file: " + cName));
             }
-            if (cInstance.name !== cBasename) {
-                return callback(new Error("Name is not correct (should be updated with the file name) in  composition file: " + cPath + ". Expected " + cBasename + " but saw " + cInstance.name));
+            if (cInstance.name !== cName) {
+                return callback(new Error("Name is not correct (should be updated with the file name) in  composition file: " + cName + ". Expected " + cName + " but saw " + cInstance.name));
             }
         });
     });
+};
+
+/**
+ * nameFromInstancePath
+ * Gets the instance name by providing the path.
+ *
+ * @name nameFromInstancePath
+ * @function
+ * @param {String} path The instance path.
+ * @return {String} The instance name.
+ */
+EngineTools.prototype.nameFromInstancePath = function (path) {
+    return Path.basename(path).slice(0, -5);
 };
 
 /**
@@ -665,7 +684,7 @@ EngineTools.prototype.setNames = function (project, callback) {
         if (err) { return callback(err); }
         var arr = [];
         Object.keys(composition).forEach(function (cPath) {
-            var cBasename = Path.basename(cPath).replace(/\.json$/, "")
+            var cBasename = self.nameFromInstance(cPath)
               , cInstance = composition[cPath]
               ;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engine-tools",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Engine Tools library and CLI app.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
Now, when calling `getComposition` we can send the `{ iName: true }` which will return only the instance names (instead of full paths):

``` js
{
  <name>: <instance-object>
}
```
